### PR TITLE
feat: RMQ message routing

### DIFF
--- a/mail_server/mail_server/doctype/mail_domain_registry/mail_domain_registry.json
+++ b/mail_server/mail_server/doctype/mail_domain_registry/mail_domain_registry.json
@@ -15,6 +15,10 @@
   "access_token",
   "domain_owner",
   "mail_client_host",
+  "section_break_imq5",
+  "include_agents",
+  "column_break_rojg",
+  "exclude_agents",
   "section_break_jcxr",
   "dkim_public_key",
   "section_break_uyww",
@@ -119,6 +123,26 @@
    "fieldtype": "Code",
    "no_copy": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "section_break_imq5",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "include_agents",
+   "fieldtype": "Small Text",
+   "label": "Include Agents",
+   "permlevel": 1
+  },
+  {
+   "fieldname": "exclude_agents",
+   "fieldtype": "Small Text",
+   "label": "Exclude Agents",
+   "permlevel": 1
+  },
+  {
+   "fieldname": "column_break_rojg",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -139,7 +163,7 @@
    "link_fieldname": "domain_name"
   }
  ],
- "modified": "2024-11-14 19:27:31.302028",
+ "modified": "2024-12-05 18:36:34.935971",
  "modified_by": "Administrator",
  "module": "Mail Server",
  "name": "Mail Domain Registry",

--- a/mail_server/mail_server/doctype/outgoing_mail_log/outgoing_mail_log.json
+++ b/mail_server/mail_server/doctype/outgoing_mail_log/outgoing_mail_log.json
@@ -42,6 +42,10 @@
   "failed_count",
   "retry_after",
   "section_break_rwda",
+  "include_agents",
+  "column_break_ekup",
+  "exclude_agents",
+  "section_break_dutw",
   "spam_check_response",
   "message"
  ],
@@ -352,12 +356,32 @@
    "label": "Subject",
    "no_copy": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "include_agents",
+   "fieldtype": "Small Text",
+   "label": "Include Agents",
+   "no_copy": 1
+  },
+  {
+   "fieldname": "column_break_ekup",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "exclude_agents",
+   "fieldtype": "Small Text",
+   "label": "Exclude Agents",
+   "no_copy": 1
+  },
+  {
+   "fieldname": "section_break_dutw",
+   "fieldtype": "Section Break"
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-05 09:56:53.109614",
+ "modified": "2024-12-05 18:46:47.419107",
  "modified_by": "Administrator",
  "module": "Mail Server",
  "name": "Outgoing Mail Log",

--- a/mail_server/rabbitmq.py
+++ b/mail_server/rabbitmq.py
@@ -90,12 +90,14 @@ class RabbitMQ:
 		exchange: str = "",
 		priority: int = 0,
 		persistent: bool = True,
+		headers: dict | None = None,
 	) -> None:
 		"""Publishes a message to the exchange with the given routing key."""
 
 		properties = pika.BasicProperties(
 			delivery_mode=pika.DeliveryMode.Persistent if persistent else None,
 			priority=priority if priority > 0 else None,
+			headers=headers if headers else {},
 		)
 		self.channel.basic_publish(
 			exchange=exchange,


### PR DESCRIPTION
https://github.com/frappe/mail_agent/pull/5

Provision to configure include and exclude agents at both the domain level and the outgoing mail level. The agent will verify the same before sending an email.