### PR TITLE
refactor: DMARC Report Viewer

### DIFF
--- a/mail_server/mail_server/doctype/dmarc_report/dmarc_report.py
+++ b/mail_server/mail_server/doctype/dmarc_report/dmarc_report.py
@@ -66,9 +66,10 @@ def create_dmarc_report(xml_content: str, incoming_mail_log: str | None = None) 
 		source_ip = row["source_ip"]
 		count = row["count"]
 		disposition = policy_evaluated["disposition"]
-		dkim_result = policy_evaluated["dkim"].upper()
-		spf_result = policy_evaluated["spf"].upper()
 		header_from = identifiers["header_from"]
+		envelope_from = identifiers.get("envelope_from", "")  # Optional
+		spf_result = policy_evaluated["spf"].upper()
+		dkim_result = policy_evaluated["dkim"].upper()
 
 		results = []
 		for auth_type, auth_result in auth_results.items():
@@ -86,9 +87,10 @@ def create_dmarc_report(xml_content: str, incoming_mail_log: str | None = None) 
 				"source_ip": source_ip,
 				"count": cint(count),
 				"disposition": disposition,
-				"dkim_result": dkim_result,
-				"spf_result": spf_result,
 				"header_from": header_from,
+				"envelope_from": envelope_from,
+				"spf_result": spf_result,
+				"dkim_result": dkim_result,
 				"auth_results": json.dumps(results, indent=4),
 			},
 		)

--- a/mail_server/mail_server/doctype/dmarc_report_detail/dmarc_report_detail.json
+++ b/mail_server/mail_server/doctype/dmarc_report_detail/dmarc_report_detail.json
@@ -13,6 +13,7 @@
   "section_break_bqnt",
   "disposition",
   "header_from",
+  "envelope_from",
   "column_break_q04b",
   "spf_result",
   "dkim_result",
@@ -81,12 +82,18 @@
   {
    "fieldname": "section_break_0qf4",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "envelope_from",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Envelope From"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-11-22 15:46:53.083901",
+ "modified": "2024-12-06 13:36:29.285052",
  "modified_by": "Administrator",
  "module": "Mail Server",
  "name": "DMARC Report Detail",

--- a/mail_server/mail_server/report/dmarc_report_viewer/dmarc_report_viewer.js
+++ b/mail_server/mail_server/report/dmarc_report_viewer/dmarc_report_viewer.js
@@ -79,6 +79,11 @@ frappe.query_reports["DMARC Report Viewer"] = {
 			fieldtype: "Data",
 		},
 		{
+			fieldname: "envelope_from",
+			label: __("Envelope From"),
+			fieldtype: "Data",
+		},
+		{
 			fieldname: "spf_result",
 			label: __("SPF Result"),
 			fieldtype: "Select",

--- a/mail_server/mail_server/report/dmarc_report_viewer/dmarc_report_viewer.js
+++ b/mail_server/mail_server/report/dmarc_report_viewer/dmarc_report_viewer.js
@@ -5,19 +5,15 @@ frappe.query_reports["DMARC Report Viewer"] = {
 	formatter(value, row, column, data, default_formatter) {
 		value = default_formatter(value, row, column, data);
 
-		const highlight_value = (condition) =>
-			condition
-				? `<span style='color:green'>${value}</span>`
-				: `<span style='color:red'>${value}</span>`;
-
 		if (["spf_result", "dkim_result", "result"].includes(column.fieldname)) {
-			value = highlight_value(data[column.fieldname] === "PASS");
+			value =
+				data[column.fieldname] === "PASS"
+					? `<span style='color:green'>${value}</span>`
+					: `<span style='color:red'>${value}</span>`;
 		} else if (column.fieldname === "source_ip" && data[column.fieldname]) {
-			value = highlight_value(data["is_local_ip"]);
-		} else if (column.fieldname === "header_from" && data[column.fieldname]) {
-			value = highlight_value(data["is_header_from_same_as_domain_name"]);
-		} else if (column.fieldname === "domain" && data[column.fieldname]) {
-			value = highlight_value(data["is_domain_same_as_domain_name"]);
+			value = data["is_local_ip"]
+				? `<span style='color:green'>${value}</span>`
+				: `<span style='color:black'>${value}</span>`;
 		}
 
 		return value;

--- a/mail_server/mail_server/report/dmarc_report_viewer/dmarc_report_viewer.py
+++ b/mail_server/mail_server/report/dmarc_report_viewer/dmarc_report_viewer.py
@@ -68,9 +68,6 @@ def get_data(filters: dict | None = None) -> list[list]:
 		for record in records:
 			record["indent"] = 1
 			record["is_local_ip"] = record["source_ip"] in local_ips
-			record["is_header_from_same_as_domain_name"] = (
-				record["header_from"] == dmarc_report["domain_name"]
-			)
 			data.append(record)
 
 			auth_results = json.loads(record.auth_results)
@@ -80,9 +77,6 @@ def get_data(filters: dict | None = None) -> list[list]:
 					auth_result.get("selector")
 					if auth_result["auth_type"] == "DKIM"
 					else auth_result.get("scope")
-				)
-				auth_result["is_domain_same_as_domain_name"] = (
-					auth_result["domain"] == dmarc_report["domain_name"]
 				)
 				data.append(auth_result)
 

--- a/mail_server/mail_server/report/dmarc_report_viewer/dmarc_report_viewer.py
+++ b/mail_server/mail_server/report/dmarc_report_viewer/dmarc_report_viewer.py
@@ -40,6 +40,7 @@ def get_columns() -> list[dict]:
 		{"label": _("Count"), "fieldname": "count", "fieldtype": "Int", "width": 70},
 		{"label": _("Disposition"), "fieldname": "disposition", "fieldtype": "Data", "width": 150},
 		{"label": _("Header From"), "fieldname": "header_from", "fieldtype": "Data", "width": 150},
+		{"label": _("Envelope From"), "fieldname": "envelope_from", "fieldtype": "Data", "width": 150},
 		{"label": _("SPF Result"), "fieldname": "spf_result", "fieldtype": "Data", "width": 150},
 		{"label": _("DKIM Result"), "fieldname": "dkim_result", "fieldtype": "Data", "width": 150},
 		{"label": _("Auth Type"), "fieldname": "auth_type", "fieldtype": "Data", "width": 150},
@@ -142,7 +143,7 @@ def get_dmarc_report_records(filters: dict, dmarc_report: str, local_ips: list) 
 
 	records_filters = {"parenttype": "DMARC Report", "parent": dmarc_report}
 
-	for field in ["source_ip", "disposition", "header_from", "spf_result", "dkim_result"]:
+	for field in ["source_ip", "disposition", "header_from", "envelope_from", "spf_result", "dkim_result"]:
 		if filters.get(field):
 			records_filters[field] = filters[field]
 
@@ -157,6 +158,7 @@ def get_dmarc_report_records(filters: dict, dmarc_report: str, local_ips: list) 
 			"count",
 			"disposition",
 			"header_from",
+			"envelope_from",
 			"spf_result",
 			"dkim_result",
 			"auth_results",


### PR DESCRIPTION
- Added `envelope_from`
- Removed color for `header_from` and `domain`
- Use black color for non-local IPs